### PR TITLE
Remove efivar dump-entries to avoid "No space left on device" error

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+mx-bootrepair (23.9) mx; urgency=medium
+
+  * Remove efivar dump-entries to avoid "No space left on device" error.
+  * Adjust version.h in debian rules
+
+ -- fehlix <fehlix@mxlinux.org>  Wed, 13 Sep 2023 17:05:38 -0400
+
 mx-bootrepair (23.8) mx; urgency=medium
 
   * Security Fix: LUKS password can end up on the console.

--- a/debian/rules
+++ b/debian/rules
@@ -3,14 +3,17 @@ export QT_SELECT=5
 
 QMAKE_OPTS = DEFINES+=NO_DEBUG_ON_CONSOLE
 MAKE_OPTS  = QMAKE=qmake-qt5 LRELEASE=lrelease-qt5 QMAKE_OPTS="$(QMAKE_OPTS)"
+DEB_BUILD_VERSION := $(shell dpkg-parsechangelog -S Version)
 
 override_dh_auto_clean:
 	dh_auto_clean
+	rm -f translations/*.qm
 	rm -f src/translations/*.qm
 
 override_dh_auto_build:
 	lrelease *.pro
-	head -n1 debian/changelog | sed -e "s/.*(\([^(]*\)).*/const QString VERSION {\"\1\"};/" > version.h
+	mv version.h version.h~
+	echo "const QString VERSION {\"$(DEB_BUILD_VERSION)\"};" > version.h
 	dh_auto_build -- $(MAKE_OPTS)
 
 override_dh_auto_install:
@@ -18,6 +21,9 @@ override_dh_auto_install:
 
 override_dh_shlibdeps:
 	dh_shlibdeps --dpkg-shlibdeps-params=--ignore-missing-info
+
+execute_after_dh_builddeb:
+	mv version.h~ version.h
 
 %:
 	dh $@ --no-automatic-dbgsym --parallel 

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -121,11 +121,15 @@ void MainWindow::installGRUB()
 
     ui->outputLabel->setText(text);
 
-    // for grub-install access UEFI NVRAM entries mount efivarfs if not already mounted
+    // for grub-install access UEFI NVRAM entries
     if (ui->grubEspButton->isChecked()) {
+        // ... mount efivarfs if not already mounted
         shell->run(QStringLiteral(
             "grep -sq ^efivarfs /proc/self/mounts || "
             "{ test -d /sys/firmware/efi/efivars && mount -t efivarfs efivarfs /sys/firmware/efi/efivars; }"));
+        // ...  remove dump-entries if exist to avoid "No space left on device" error
+        shell->run(QStringLiteral(
+            "ls -1 /sys/firmware/efi/efivars | grep -sq ^dump && rm /sys/firmware/efi/efivars/dump*"));
     }
     if (mountChrootEnv(root)) {
         if (!checkAndMountPart(tmpdir.path(), QStringLiteral("/boot"))) {


### PR DESCRIPTION
* Remove efivar dump-entries to avoid "No space left on device" error.
* Adjust version.h in debian rules
